### PR TITLE
Genie module name needed with startup() function

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@ end
           <pre>
             <code class="language-julia">
 # Start the web server and visit http://localhost:8000/hello in your favorite browser
-julia> startup()
+julia> up()
 
 Ready
 Web Server starting at 127.0.0.1:8000


### PR DESCRIPTION
```
julia> using Genie

julia> startup()
ERROR: UndefVarError: startup not defined
Stacktrace:
 [1] top-level scope at REPL[4]:1

julia> Genie.startup()
Web Server starting at http://0.0.0.0:8000 
Web Server running at http://0.0.0.0:8000 
Genie.AppServer.ServersCollection(Task (runnable) @0x00007f130fed04f0, nothing)
```