### PR TITLE
Fix Doc Link on Website

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@ Web Server running at 127.0.0.1:8000
         <img src="img/docs.png" class="speaker-img" alt="The docs">
         <h3>The docs</h3>
         <p>Check out the Getting Starting Guide.</p>
-        <a href="https://genieframework.github.io/Genie.jl/guides/Working_With_Genie_Apps.html" target="_blank">Read the docs</a>
+        <a href="https://genieframework.github.io/Genie.jl/dev/index.html" target="_blank">Read the docs</a>
       </div>
       <div class="col-sm-6 col-md-6 feature">
         <img src="img/community.png" class="speaker-img" alt="Get in touch">


### PR DESCRIPTION
I noticed the Read the Docs link was broken (404) on the Genie website. I changed it to where I think it should point.